### PR TITLE
Fixes a few issues with loading resources on the main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,12 +9,12 @@
     <meta name="description" content="herd Open Source Landing Page">
     <meta name="author" content="herd Contributors">
     <meta name="description" content="Font Awesome, the iconic font and CSS framework">
-    <link rel="shortcut icon" href="http://finraos.github.io/docs-assets/ico/favicon.png">
+    <link rel="shortcut icon" href="https://finraos.github.io/docs-assets/ico/favicon.png">
 
     <title>herd big data</title>
 
     <!-- Bootstrap core CSS -->
-    <link href="http://finraos.github.io/herd/dist/css/bootstrap.css" rel="stylesheet">
+    <link href="https://finraos.github.io/herd/dist/css/bootstrap.css" rel="stylesheet">
 	<link href="./herd_files/CLIP_embed.css" rel="stylesheet" type="text/css">
 
     <!-- Just for debugging purposes. Don't actually copy this line! -->
@@ -68,18 +68,18 @@
         </div>
 		   <div class="navbar-collapse collapse">
 			  <ul class="nav navbar-nav">
-                  <li><a href="http://finraos.github.io/herd/#get_involved" onclick="_gaq.push([&#39;_trackEvent&#39;, &#39;Click&#39;, &#39;Menu-Get Involved&#39;]);">Get Involved</a></li>
+                  <li><a href="https://finraos.github.io/herd/#get_involved" onclick="_gaq.push([&#39;_trackEvent&#39;, &#39;Click&#39;, &#39;Menu-Get Involved&#39;]);">Get Involved</a></li>
 				<li class="dropdown" style="z-index:9999;">
-                    <a href="http://finraos.github.io/herd/#" class="dropdown-toggle" data-toggle="dropdown" style="z-index:9999;" onclick="_gaq.push([&#39;_trackEvent&#39;, &#39;Click&#39;, &#39;Menu-Documentation&#39;]);">Documentation<b class="caret"></b></a>
+                    <a href="https://finraos.github.io/herd/#" class="dropdown-toggle" data-toggle="dropdown" style="z-index:9999;" onclick="_gaq.push([&#39;_trackEvent&#39;, &#39;Click&#39;, &#39;Menu-Documentation&#39;]);">Documentation<b class="caret"></b></a>
                     <ul class="dropdown-menu" style="z-index:9999;">
                         <li><a href="https://github.com/FINRAOS/herd/wiki" style="z-index:9999;" target="_blank">herd Wiki</a></li>
-                        <li><a href="http://finraos.github.io/herd/docs/0.1.0/rest/index.html" style="z-index:9999;" target="_blank">herd API Docs</a></li>
+                        <li><a href="https://finraos.github.io/herd/docs/0.1.0/rest/index.html" style="z-index:9999;" target="_blank">herd API Docs</a></li>
                     </ul>
                 </li>
                   <li><a href="https://github.com/FINRAOS/herd/issues" target="_blank" onclick="_gaq.push([&#39;_trackEvent&#39;,
 &#39;Click&#39;, &#39;Menu-GitHub Issues&#39;]);">GitHub Issues</a></li>
-				<li><a href="http://finraos.github.io/herd/#previous_releases" onclick="_gaq.push([&#39;_trackEvent&#39;, &#39;Click&#39;, &#39;Menu-Previous Releases&#39;]);">Previous Releases</a></li>
-				<li><a href="http://finraos.github.io/herd/#about" onclick="_gaq.push([&#39;_trackEvent&#39;, &#39;Click&#39;, &#39;Menu-About&#39;]);">About</a></li>
+				<li><a href="https://finraos.github.io/herd/#previous_releases" onclick="_gaq.push([&#39;_trackEvent&#39;, &#39;Click&#39;, &#39;Menu-Previous Releases&#39;]);">Previous Releases</a></li>
+				<li><a href="https://finraos.github.io/herd/#about" onclick="_gaq.push([&#39;_trackEvent&#39;, &#39;Click&#39;, &#39;Menu-About&#39;]);">About</a></li>
 
 			  </ul>
             </div>
@@ -184,7 +184,7 @@ By making a contribution to this project, I certify that:<br>
 			<p></p>
 		</li>
 		
-		<li><p>Once you have completed the commit, you can make a <a href="http://help.github.com/send-pull-requests/" target="_new">pull request</a> referencing the initial issue created for the work.</p></li>
+		<li><p>Once you have completed the commit, you can make a <a href="https://help.github.com/send-pull-requests/" target="_new">pull request</a> referencing the initial issue created for the work.</p></li>
             <li><p>The herd team will process your pull request in a timely fashion and may perform additional testing. You will receive feedback or a notification that your code will be accepted with an indication of the timeframe for acceptance.</p></li>
             <li><p>All activity regarding the issue including contributor and herd team discussions will occur within the GitHub issues system, so check back frequently and watch issues that interest you.</p></li>
 
@@ -234,7 +234,7 @@ By making a contribution to this project, I certify that:<br>
 		
 		
 
-		<p><a class="btn btn-primary" role="button" href="http://finraos.github.io" onclick="_gaq.push([&#39;_trackEvent&#39;, &#39;Download&#39;, &#39;Download-Release V000&#39;]);">Download WAR Release v000</a><font color="red"><b>&nbsp;&nbsp;(This release is DEPRECATED!)</b></font></p>
+		<p><a class="btn btn-primary" role="button" href="https://finraos.github.io" onclick="_gaq.push([&#39;_trackEvent&#39;, &#39;Download&#39;, &#39;Download-Release V000&#39;]);">Download WAR Release v000</a><font color="red"><b>&nbsp;&nbsp;(This release is DEPRECATED!)</b></font></p>
 		</div>
 	   <br>
         -->
@@ -282,7 +282,7 @@ By making a contribution to this project, I certify that:<br>
                 <td class="alert" ><img src="./herd_files/k26425_LThumb.jpg" height="96" width="80"></td><td class="alert" ><b>Sai Suryanarayanan</b><br><a href="https://www.linkedin.com/in/saisumughisuryanarayanan" target="_new">Linkedin</a></td>
                 </tr>
             <tr>
-                    <td class="alert" ><img src="./herd_files/wang_LThumb.jpg" height="96" width="80"></td><td class="alert" ><b>Wayne Wang</b><br><a href="http://www.linkedin.com/in/needWayneProfileLink" target="_new">Linkedin</a></td>
+                    <td class="alert" ><img src="./herd_files/wang_LThumb.jpg" height="96" width="80"></td><td class="alert" ><b>Wayne Wang</b><br><a href="https://www.linkedin.com/in/needWayneProfileLink" target="_new">Linkedin</a></td>
                     <td class="alert" ><img src="./herd_files/Weisz_LThumb.jpg" height="96" width="80"></td><td class="alert" ><b>Nate Weisz</b><br><a href="https://www.linkedin.com/in/nateweisz" target="_new">Linkedin</a></td>
                 <td class="alert" ><img src="./herd_files/wolffp_LThumb.jpg" height="96" width="80"></td><td class="alert" ><b>Greg Wolff</b><br><a href="https://www.linkedin.com/pub/greg-wolff/1/ba/aa8" target="_new">Linkedin</a></td>
                 </tr>


### PR DESCRIPTION
This is a small change, but basically the current page loads CSS using http:// hard links instead of https:// hard links. Some browsers, such as Google Chrome, won't accept this mismatch in protocol security. Here, I quickly fix some of those references so the gh-pages website works properly (and looks good again)!

You can see a working version of my PR here: [https://malsf21.github.io/herd/](https://malsf21.github.io/herd/)